### PR TITLE
Added a short script to find and wrap URLs in <a> tags to HTML output

### DIFF
--- a/anchore/anchore_utils.py
+++ b/anchore/anchore_utils.py
@@ -690,11 +690,29 @@ def print_result(config, result, outputmode=None):
                     if tablemode == 'stdout':
                         print t.get_string(sortby=sortby, reversesort=True)
                     elif tablemode == 'html':
+			print ("""<script src=\"https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js\"></script>
+				<script>
+					$(document).ready(function(){
+       						$(\"td:contains('http')\").each(function() {
+           						$(this).wrapInner('<a href=\"' + $(this).text() + '\"/>');
+       						});
+					});
+				</script>""")
+
                         print t.get_html_string(sortby=sortby, reversesort=True).encode('utf8')
                 else:
                     if tablemode == 'stdout':
                         print t
                     elif tablemode == 'html':
+			print ("""<script src=\"https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js\"></script>
+				<script>
+					$(document).ready(function(){
+        					$(\"td:contains('http')\").each(function() {
+           						$(this).wrapInner('<a href=\"' + $(this).text() + '\"/>');
+       						});
+					});
+				</script>""")
+
                         print t.get_html_string().encode('utf8')
                 print ""
             elif outputmode == 'plaintext':


### PR DESCRIPTION
This is a pretty clunky way to wrap the URLs in <a> tags but I figured this may be easiest way to accomplish this as I believe the table used to generate the HTML report is an immutable type.  It just prints this script with the HTML output so that when it is outputted to an HTML file it automatically links all of the strings that are URLs.