### PR TITLE
Remove outdated modules dirs and scripts.

### DIFF
--- a/anchore/anchore-modules/inputs/README
+++ b/anchore/anchore-modules/inputs/README
@@ -1,5 +1,0 @@
-Place executable scripts in this directory to be run in lexicographic order when someone runs:
-anchore sync user-images input
-
-This is intended to hold scripts to pull user images to the local host for analysis etc.
-

--- a/anchore/anchore-modules/outputs/README
+++ b/anchore/anchore-modules/outputs/README
@@ -1,5 +1,0 @@
-Place executable scripts in this directory to be run in lexicographic order when someone runs:
-anchore sync user-images output
-
-This is intended to hold scripts to push user images to external registries from the local host after analysis or gating, etc.
-

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ package_data = {
                    'anchore-modules/gates/*',
                    'anchore-modules/queries/*',
                    'anchore-modules/multi-queries/*',
-                   'anchore-modules/inputs/*',
-                   'anchore-modules/outputs/*',
                    'anchore-modules/shell-utils/*',
                    'anchore-modules/examples/queries/*',
                    'anchore-modules/examples/multi-queries/*',


### PR DESCRIPTION
Found these when searching the repo for deprecated commands. Searched the code and can't find any instance of these being used anymore, so proposing removing them to avoid confusion.

Signed-off-by: Matt Jaynes <matt@nanobeep.com>