### PR TITLE
Update image badge to point to current image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://anchore.io/service/badges/image/f017354b717234ebfe1cf1c5d538ddc8618f3ab0d8c67e290cf37f578093d121
-    :target: https://anchore.io/image/dockerhub/f017354b717234ebfe1cf1c5d538ddc8618f3ab0d8c67e290cf37f578093d121?repo=anchore%2Fcli&tag=latest#overview
+.. image:: https://anchore.io/service/badges/image/64e95dd583882673b5ea2957bbff88e308c7c95a3bf26c0c88c7014d92281dae
+    :target: https://anchore.io/image/dockerhub/64e95dd583882673b5ea2957bbff88e308c7c95a3bf26c0c88c7014d92281dae?repo=anchore%2Fcli&tag=latest#overview
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://anchore.io/service/badges/image/64e95dd583882673b5ea2957bbff88e308c7c95a3bf26c0c88c7014d92281dae
-    :target: https://anchore.io/image/dockerhub/64e95dd583882673b5ea2957bbff88e308c7c95a3bf26c0c88c7014d92281dae?repo=anchore%2Fcli&tag=latest#overview
+    :target: https://anchore.io/image/dockerhub/anchore%2Fcli%3Alatest
 
 
 


### PR DESCRIPTION
The previous image badge was linking to an older [policy-failing docker image](https://anchore.io/image/dockerhub/f017354b717234ebfe1cf1c5d538ddc8618f3ab0d8c67e290cf37f578093d121?repo=anchore%2Fcli&tag=latest#policy). Updating the link and image src to point to the current docker image id (which is policy-passing).

Note: I was tempted to set the url to [the permalink for this docker image](https://anchore.io/image/dockerhub/anchore%2Fcli%3Alatest) so that it wouldn't need updating each time the docker image is updated. However, the downside of doing that would be not having the evolving docker image ids tracked along with versions of Anchore in version control. If there is a checklist for when the docker image is updated, it might be good to add a task to it to update this README during that process. (Or perhaps add a var to the README that can be auto-updated in the CI/CD cycle).
 
Signed-off-by: Matt Jaynes <matt@nanobeep.com>