### PR TITLE
Update image badge url to use navigator permalink

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 .. image:: https://anchore.io/service/badges/image/f017354b717234ebfe1cf1c5d538ddc8618f3ab0d8c67e290cf37f578093d121
-    :target: https://anchore.io/image/dockerhub/f017354b717234ebfe1cf1c5d538ddc8618f3ab0d8c67e290cf37f578093d121?repo=anchore%2Fcli&tag=latest#overview
+    :target: https://anchore.io/image/dockerhub/anchore%2Fcli%3Alatest
 
 
 


### PR DESCRIPTION
The previous image badge url was for an older policy-failing docker image.

Signed-off-by: Matt Jaynes <matt@nanobeep.com>