### PR TITLE
Updated requirements to use 'docker' instead

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-docker-py
+docker
 prettytable
 click
 requests


### PR DESCRIPTION
The 'docker-py' package have been deprecated in favor of 'docker'

In environments with docker-compose, it complains that an older version of 'docker-py' may cause issues.